### PR TITLE
feat: pagination adaptation

### DIFF
--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -39,10 +39,15 @@ class UserController {
 
     public function home() {
         $users = [];
+        $page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
+        $limit = 5; 
+        $offset = ($page - 1) * $limit;
 
         if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true) {
             if (in_array($_SESSION['role'], ['user', 'admin'])) {
-                $users = $this->userModel->getAll();
+                $users = $this->userModel->getUsersPaginated($limit, $offset);
+                $totalUsers = $this->userModel->getTotalUsers();
+                $totalPages = ceil($totalUsers / $limit);
             }
         }
 

--- a/app/models/User.php
+++ b/app/models/User.php
@@ -48,4 +48,17 @@ class User {
         $stmt = $this->db->prepare("UPDATE users SET role = :role WHERE id = :id");
         return $stmt->execute([':role' => $role, ':id' => $id]);
     }
+
+    public function getUsersPaginated($limit, $offset) {
+        $stmt = $this->db->prepare("SELECT * FROM users LIMIT :limit OFFSET :offset");
+        $stmt->bindValue(':limit', (int)$limit, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', (int)$offset, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function getTotalUsers() {
+        $stmt = $this->db->query("SELECT COUNT(*) as total FROM users");
+        return $stmt->fetch(PDO::FETCH_ASSOC)['total'];
+    }
 }

--- a/app/views/partials/usersTable.php
+++ b/app/views/partials/usersTable.php
@@ -75,6 +75,17 @@ $isLoggedIn = $isLoggedIn ?? false;
         <?php endif; ?>
       </tbody>
     </table>
+    
+    <?php if (!empty($filteredUsers)): ?>
+      <div class="pagination">
+        <?php for ($i = 1; $i <= $totalPages; $i++): ?>
+          <a href="?page=<?= $i ?><?= !empty($search) ? '&search=' . urlencode($search) : '' ?>"
+            class="<?= ($i == $page) ? 'active' : '' ?>">
+            <?= $i ?>
+          </a>
+        <?php endfor; ?>
+      </div>
+    <?php endif; ?>
                
   </section>
 <?php endif; ?>


### PR DESCRIPTION
1. Controller (HomeController.php)
- Added pagination logic in the home() method
- Captures the page number via $_GET['page'] (default: page 1)
- Sets a limit of 5 users per page
- Calculates the offset to retrieve correct records
- Replaced the getAll() call with getUsersPaginated() to retrieve only records on the current page
- Added calculation of the total number of pages

2. Model (User.php)
- New getUsersPaginated() method: searches for users with LIMIT and OFFSET for pagination
- New getTotalUsers() method: returns the total number of registered users to calculate the number of pages

3. View (usersTable.php)
- Added visual pagination component
- Numeric links to navigate between pages